### PR TITLE
Convert to Endpoints

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -1,52 +1,23 @@
-from charms.reactive import hook
-from charms.reactive import RelationBase
-from charms.reactive import scopes
-from charms.reactive import is_state
+from charms.reactive import Endpoint
+from charms.reactive import toggle_flag
 
 
-class CephClient(RelationBase):
-    scope = scopes.GLOBAL
-    auto_accessors = ['key', 'fsid', 'auth', 'mon_hosts']
+class CephClient(Endpoint):
+    def manage_flags(self):
+        toggle_flag(self.expand_name('{endpoint_name}.available'),
+                    all([self.key(),
+                         self.fsid(),
+                         self.auth(),
+                         self.mon_hosts()]))
 
-    @hook('{requires:ceph-admin}-relation-{joined,changed}')
-    def changed(self):
-        self.set_state('{relation_name}.connected')
-        key = None
-        fsid = None
-        auth = None
-        mon_hosts = None
+    def key(self):
+        return self.all_joined_units.received_raw['key']
 
-        try:
-            key = self.key
-        except AttributeError:
-            pass
+    def fsid(self):
+        return self.all_joined_units.received_raw['fsid']
 
-        try:
-            fsid = self.fsid
-        except AttributeError:
-            pass
+    def auth(self):
+        return self.all_joined_units.received_raw['auth']
 
-        try:
-            auth = self.auth
-        except AttributeError:
-            pass
-
-        try:
-            mon_hosts = self.mon_hosts
-        except AttributeError:
-            pass
-
-        data = {
-            'key': key,
-            'fsid': fsid,
-            'auth': auth,
-            'mon_hosts': mon_hosts
-        }
-
-        if all(data.values()):
-            self.set_state('{relation_name}.available')
-
-    @hook('{requires:ceph-admin}-relation-{broken,departed}')
-    def broken(self):
-        if is_state('{relation_name}.available'):
-            self.remove_state('{relation_name}.available')
+    def mon_hosts(self):
+        return self.all_joined_units.received_raw['mon_hosts']


### PR DESCRIPTION
This prevents an issue where the available flag is incorrectly cleared when a single unit departs the relation.